### PR TITLE
Added Users table and History table

### DIFF
--- a/quizbit/quiz/models.py
+++ b/quizbit/quiz/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.contrib.auth.hashers import make_password
+from django.core.exceptions import ValidationError
+from .models import Users, Questions
+import re
 
 
 class Questions(models.Model):
@@ -12,7 +16,7 @@ class Questions(models.Model):
 
     # Field for question title
     # This field is for showing the question
-    ques_title = models.CharField(max_length=255)
+    ques_title = models.TextField()
 
     # Field for question details
     # This field is for retrieving details about the question
@@ -28,7 +32,7 @@ class Questions(models.Model):
 
     def save(self, *args, **kwargs):
         """
-        This function ensures `ques_number` is auto-incremented
+        This function ensures ques_number is auto-incremented
         and adjusted after deletions.
         """
         if not self.pk:
@@ -40,7 +44,7 @@ class Questions(models.Model):
 
     def delete(self, *args, **kwargs):
         """
-        This function ensures to fix `ques_number` values after deletion.
+        This function ensures to fix ques_number values after deletion.
         """
         super().delete(*args, **kwargs)
 
@@ -52,3 +56,73 @@ class Questions(models.Model):
 
     def __str__(self):
         return self.ques_title
+
+
+
+class Users(models.Model):
+    # Primary key field for users
+    user_id = models.AutoField(primary_key=True)
+
+    # Username with restricted special characters
+    # Username is restricted to 15 characters and allows only letters, numbers, underscores and dots.
+    # Uses regex for checking validity.
+    user_name = models.CharField(
+        max_length=15,
+        unique=True,
+        validators=[
+            models.RegexValidator(
+                regex=r'^[a-zA-Z0-9_.]+$',
+                message="Username can only contain letters, numbers, underscores, and dots.",
+            )
+        ]
+    )
+
+    # Encrypted password
+    # Password is hashed before saving in the database
+    password = models.CharField(
+        max_length=128  # Default max length for Django password hashes
+    )
+
+    # Email validation
+    email = models.EmailField(unique=True)
+
+    def save(self, *args, **kwargs):
+        if not re.search(r'\s', self.password):  # Ensure no spaces in the password
+            self.password = make_password(self.password)
+        else:
+            raise ValueError("Password cannot contain spaces.")
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return self.user_name
+
+
+class History(models.Model):
+    # Foreign key referencing the Users table
+    user_id = models.ForeignKey(Users, on_delete=models.CASCADE)
+
+    # Foreign key referencing the Questions table
+    ques_id = models.ForeignKey(Questions, on_delete=models.CASCADE)
+
+    # Answer provided by the user
+    answer = models.PositiveIntegerField()
+
+    # Boolean field for correctness
+    is_correct = models.BooleanField(default=False)
+
+    def save(self, *args, **kwargs):
+        """
+        Method to determine if the answer is correct
+        based on the ques_answer field in the Questions table.
+        """
+        if not self.ques_id:
+            raise ValidationError("Question ID cannot be null.")
+
+        # Check if the user's answer matches the correct answer
+        correct_answer = self.ques_id.ques_answer  # Get correct answer from the related question
+        self.is_correct = (self.answer == correct_answer)
+
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"User: {self.user_id.user_name}, Question: {self.ques_id.ques_title}, Correct: {self.is_correct}"


### PR DESCRIPTION
In this commit I have added the rest of the schemas of my database. The Users schema consists of information about the users. The schema has fields known as user_id, user_name (allowed 15 characters), password (hashed in the database), email. The History table consists of information about all the users practice history. The schema consists of foreign keys user_id from Users schema and ques_id from Questions table. It also has the answer the user inputted and is_correct field to see if the answer is correct.